### PR TITLE
Replace JSHint with ESLint

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -119,7 +119,7 @@ If you like or are using this project to learn or start your solution, please gi
     - [Passport](http://www.passportjs.org/)
     - [Nodemailer](https://nodemailer.com/about/)
     - [Marked](https://marked.js.org/#/README.md#README.md)
-    - [Eslint](https://eslint.org/)
+    - [ESlint](https://eslint.org/)
 
 12. Testing
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -119,7 +119,7 @@ If you like or are using this project to learn or start your solution, please gi
     - [Passport](http://www.passportjs.org/)
     - [Nodemailer](https://nodemailer.com/about/)
     - [Marked](https://marked.js.org/#/README.md#README.md)
-    - [ESlint](https://eslint.org/)
+    - [ESLint](https://eslint.org/)
 
 12. Testing
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -119,7 +119,7 @@ If you like or are using this project to learn or start your solution, please gi
     - [Passport](http://www.passportjs.org/)
     - [Nodemailer](https://nodemailer.com/about/)
     - [Marked](https://marked.js.org/#/README.md#README.md)
-    - [JSHint](https://github.com/jshint/jshint)
+    - [Eslint](https://eslint.org/)
 
 12. Testing
 


### PR DESCRIPTION
Motivation:
- usability (https://www.npmtrends.com/eslint-vs-jshint)
- maintainability (eslint leading over jshint with16.5K stars vs 8.6K stars on Github)